### PR TITLE
I wanna pony

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The vignette produces a [handy dashboard](https://cransays.itsalocke.com/article
 
 * The [`foghorn` package](https://github.com/fmichonneau/foghorn), to summarize CRAN Check Results in the Terminal, provides an `foghorn::cran_incoming()` function to where your package stands in the CRAN incoming queue.
 
-* If you wanna increase the chance of a smooth submission, check out [this collaborative list of things to know before submitting to CRAN](https://github.com/ThinkR-open/prepare-for-cran).
+* If you want to increase the chance of a smooth submission, check out [this collaborative list of things to know before submitting to CRAN](https://github.com/ThinkR-open/prepare-for-cran).
 
 ## Deployment
 
@@ -36,7 +36,7 @@ The pkgdown website is deployed from Travis, the setup was made using [`travis::
 
 ## Contributing
 
-Wanna report a bug or suggest a feature? Great stuff! For more information on how to contribute check out [our contributing guide](.github/CONTRIBUTING.md). 
+Want to report a bug or suggest a feature? Great stuff! For more information on how to contribute check out [our contributing guide](.github/CONTRIBUTING.md). 
 
 Please note that this R package is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this package project you agree to abide by its terms.
 


### PR DESCRIPTION
Use of "wanna" instead of "want to" sounds really childish, and I have had students submit papers using "wanna" in formal submissions. Let's not encourage it.