### PR TITLE
Convert Sys.time to CRAN timezone (fix #15)

### DIFF
--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -31,7 +31,7 @@ take_snapshot <- function(){
       cran_incoming
     ) %>%
     dplyr::mutate(
-      snapshot_time = Sys.time()
+      snapshot_time = format(Sys.time(), tz="Europe/Vienna")
     )
 
   # Tidy results ------------------------------------------------------

--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -31,14 +31,14 @@ take_snapshot <- function(){
       cran_incoming
     ) %>%
     dplyr::mutate(
-      snapshot_time = format(Sys.time(), tz="Europe/Vienna")
+      snapshot_time = as.POSIXct(format(Sys.time(), tz="Europe/Vienna"))
     )
 
   # Tidy results ------------------------------------------------------
   cran_incoming <- cran_incoming %>%
     dplyr::filter(grepl(".*\\.tar\\.gz", V9)) %>% # Remove non-package files
     dplyr::mutate(
-      year = ifelse(grepl(":", V8, fixed = TRUE), format(Sys.Date(), "%Y"), V8),
+      year = ifelse(grepl(":", V8, fixed = TRUE), format(snapshot_time, "%Y"), V8),
       time = ifelse(grepl(":", V8, fixed = TRUE), V8, "00:00"),
       package = sub("\\.tar\\.gz", "", V9), # Remove package extension
       submission_time = as.POSIXct(paste(year, V6, V7, time), format = "%Y %b %d %R"),


### PR DESCRIPTION
I'm happy to revise this PR as much as necessary until it's ready for production.

Some important points:

- ~~The dashboard will now display the same time as the CRAN server (UTC+2). Do you think it would make more sense to use something else?~~ Actually, the time displayed on the dashboard is defined in the vignette so it should change anything.
- The timezone of the CRAN server is currently hardcoded. As mentioned in https://github.com/lockedata/cransays/issues/15#issuecomment-428663171, it may be possible to determine the timezone by looking at the content of the `TIME` file but it may be a lot of effort for a very minimal gain.
- I would be more comfortable if someone out of the UTC+2 timezone could test this. I share the CRAN server timezone so I can quite easily be fooled into thinking my code works when it actually doesn't.