### PR TITLE
Put 'dashboard' link directly in navbar

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,3 +6,15 @@ authors:
   Locke Data:
     href: "https://itsalocke.com/"
     html: "<img src='https://github.com/lockedatapublished.png' height=24>"
+
+
+navbar:
+  title: ~
+  type: default
+  left:
+    - icon: fa-home fa-lg
+      href: index.html
+    - text: Reference
+      href: reference/index.html
+    - text: Dashboard
+      href: articles/dashboard.html


### PR DESCRIPTION
Instead of having to click on 'articles' (which isn't really an accurate description of the actual content), and then on 'CRAN incoming dashboard' in the dropdown menu.