### PR TITLE
Fix broken action

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
       - uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
-        run: Rscript -e 'install.packages("https://github.com/r-lib/remotes/archive/master.tar.gz", repos = NULL)' -e 'remotes::install_deps(dependencies = TRUE)'
+        run: Rscript -e 'install.packages("remotes")' -e 'remotes::install_deps(dependencies = TRUE)'
       - name: Cache R packages
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
It looks like the actions workflow is broken because it can't install remotes from that URL. Maybe we can default to remotes from CRAN?